### PR TITLE
fix [#18]: uses systemd-run for the auto export in apt

### DIFF
--- a/includes.container/usr/share/vso/hooks/apt-post
+++ b/includes.container/usr/share/vso/hooks/apt-post
@@ -1,4 +1,10 @@
 #!/bin/bash
+if [ -z $SUDO_UID ]
+then
+    echo "not running with sudo, export the app manually with vso export"
+    exit 0
+fi
+
 apt-mark showmanual > /tmp/vso-manually-installed-packages-after
 installed_apps="$(grep -v -f /tmp/vso-manually-installed-packages-before /tmp/vso-manually-installed-packages-after)"
 
@@ -10,12 +16,11 @@ while IFS= read -r app_to_export
 do
     if [[ "x$app_to_export" == "x" ]]; then continue; fi
     echo trying to export $app_to_export
-    echo "host-shell vso export --app $app_to_export" >> "$export_commands_file"
+    echo "vso export --app $app_to_export" >> "$export_commands_file"
 done <<< "$installed_apps"
 
 # run bash file as the user
 if [ -s "$export_commands_file" ]
 then
-    user_environment="XDG_RUNTIME_DIR=/run/user/$SUDO_UID; DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$SUDO_UID/bus;"
-    su -c "su -c \"$user_environment bash $export_commands_file > /dev/null 2> /dev/null \" $SUDO_USER"
+    systemd-run --user --machine="$SUDO_UID@.host" /usr/bin/host-shell bash $export_commands_file &> /dev/null
 fi


### PR DESCRIPTION
The script to export new apps when installing with apt already broke two times because of updates to various components. 
So settings the environment variables manually doesn't seem to be a great option. 

systemd-run provides the functionality to basically mimic another user with all their environment variables, so it is much more robust then the current approach. 

Fixes #18 