### PR TITLE
fix: Force bash in host-shell

### DIFF
--- a/includes.container/usr/bin/host-shell
+++ b/includes.container/usr/bin/host-shell
@@ -12,7 +12,8 @@ fi
 if [ "$(basename "${0}")" != "host-shell" ]; then
     host_command="$(basename "${0}")"
 else
-    host_command="${1:-${SHELL:-/bin/sh}}"
+    host_shell=$(grep "^$USER" /run/host/etc/passwd | awk -F: '{print $NF}')
+    host_command="${1:-${$host_shell:-/bin/bash}}"
     shift
 fi
 


### PR DESCRIPTION
If the user changed their default shell inside the vso container, `host-shell` would fail if called without any arguments and the same shell wasn't installed on the host. This PR fixes this by retrieving the user's default shell in the host system.