### PR TITLE
feat: add manpath configuration file to the container

### DIFF
--- a/includes.container/etc/man-path.config
+++ b/includes.container/etc/man-path.config
@@ -1,0 +1,135 @@
+# manpath.config
+#
+# This file is used by the man-db package to configure the man and cat paths.
+# It is also used to provide a manpath for those without one by examining
+# their PATH environment variable. For details see the manpath(5) man page.
+#
+# Lines beginning with `#' are comments and are ignored. Any combination of
+# tabs or spaces may be used as `whitespace' separators.
+#
+# There are three mappings allowed in this file:
+# --------------------------------------------------------
+# MANDATORY_MANPATH			manpath_element
+# MANPATH_MAP		path_element	manpath_element
+# MANDB_MAP		global_manpath	[relative_catpath]
+#---------------------------------------------------------
+# every automatically generated MANPATH includes these fields
+#
+#MANDATORY_MANPATH 			/usr/src/pvm3/man
+#
+MANDATORY_MANPATH			/usr/man
+MANDATORY_MANPATH			/usr/share/man
+MANDATORY_MANPATH			/usr/local/share/man
+MANDATORY_MANPATH			/run/host/usr/man
+MANDATORY_MANPATH			/run/host/usr/share/man
+MANDATORY_MANPATH			/run/host/usr/local/share/man
+#---------------------------------------------------------
+# set up PATH to MANPATH mapping
+# ie. what man tree holds man pages for what binary directory.
+#
+#		*PATH*        ->	*MANPATH*
+#
+MANPATH_MAP	/bin			/usr/share/man
+MANPATH_MAP	/usr/bin		/usr/share/man
+MANPATH_MAP	/sbin			/usr/share/man
+MANPATH_MAP	/usr/sbin		/usr/share/man
+MANPATH_MAP	/usr/local/bin		/usr/local/man
+MANPATH_MAP	/usr/local/bin		/usr/local/share/man
+MANPATH_MAP	/usr/local/sbin		/usr/local/man
+MANPATH_MAP	/usr/local/sbin		/usr/local/share/man
+MANPATH_MAP	/usr/X11R6/bin		/usr/X11R6/man
+MANPATH_MAP	/usr/bin/X11		/usr/X11R6/man
+MANPATH_MAP	/usr/games		/usr/share/man
+MANPATH_MAP	/opt/bin		/opt/man
+MANPATH_MAP	/opt/sbin		/opt/man
+#---------------------------------------------------------
+# For a manpath element to be treated as a system manpath (as most of those
+# above should normally be), it must be mentioned below. Each line may have
+# an optional extra string indicating the catpath associated with the
+# manpath. If no catpath string is used, the catpath will default to the
+# given manpath.
+#
+# You *must* provide all system manpaths, including manpaths for alternate
+# operating systems, locale specific manpaths, and combinations of both, if
+# they exist, otherwise the permissions of the user running man/mandb will
+# be used to manipulate the manual pages. Also, mandb will not initialise
+# the database cache for any manpaths not mentioned below unless explicitly
+# requested to do so.
+#
+# In a per-user configuration file, this directive only controls the
+# location of catpaths and the creation of database caches; it has no effect
+# on privileges.
+#
+# Any manpaths that are subdirectories of other manpaths must be mentioned
+# *before* the containing manpath. E.g. /usr/man/preformat must be listed
+# before /usr/man.
+#
+#		*MANPATH*     ->	*CATPATH*
+#
+MANDB_MAP	/usr/man		/var/cache/man/fsstnd
+MANDB_MAP	/usr/share/man		/var/cache/man
+MANDB_MAP	/usr/local/man		/var/cache/man/oldlocal
+MANDB_MAP	/usr/local/share/man	/var/cache/man/local
+MANDB_MAP	/usr/X11R6/man		/var/cache/man/X11R6
+MANDB_MAP	/opt/man		/var/cache/man/opt
+MANDB_MAP	/snap/man		/var/cache/man/snap
+#
+#---------------------------------------------------------
+# Program definitions.  These are commented out by default as the value
+# of the definition is already the default.  To change: uncomment a
+# definition and modify it.
+#
+#DEFINE 	pager	pager
+#DEFINE 	cat	cat
+#DEFINE 	tr	tr '\255\267\264\327' '\055\157\047\170'
+#DEFINE		grep	grep
+#DEFINE 	troff 	groff -mandoc
+#DEFINE 	nroff 	nroff -mandoc
+#DEFINE 	eqn 	eqn
+#DEFINE 	neqn	neqn
+#DEFINE 	tbl 	tbl
+#DEFINE 	col 	col
+#DEFINE 	vgrind 	vgrind
+#DEFINE 	refer 	refer
+#DEFINE 	grap 	grap
+#DEFINE 	pic 	pic -S
+#
+#DEFINE		compressor	gzip -c7
+#---------------------------------------------------------
+# Misc definitions: same as program definitions above.
+#
+#DEFINE		whatis_grep_flags		-i
+#DEFINE		apropos_grep_flags		-iEw
+#DEFINE		apropos_regex_grep_flags	-iE
+#---------------------------------------------------------
+# Section names. Manual sections will be searched in the order listed here;
+# the default is 1, n, l, 8, 3, 0, 2, 3type, 5, 4, 9, 6, 7. Multiple SECTION
+# directives may be given for clarity, and will be concatenated together in
+# the expected way.
+# If a particular extension is not in this list (say, 1mh), it will be
+# displayed with the rest of the section it belongs to. The effect of this
+# is that you only need to explicitly list extensions if you want to force a
+# particular order. Sections with extensions should usually be adjacent to
+# their main section (e.g. "1 1mh 8 ...").
+#
+SECTION		1 n l 8 3 0 2 3type 3posix 3pm 3perl 3am 5 4 9 6 7
+#
+#---------------------------------------------------------
+# Range of terminal widths permitted when displaying cat pages. If the
+# terminal falls outside this range, cat pages will not be created (if
+# missing) or displayed.
+#
+#MINCATWIDTH	80
+#MAXCATWIDTH	80
+#
+# If CATWIDTH is set to a non-zero number, cat pages will always be
+# formatted for a terminal of the given width, regardless of the width of
+# the terminal actually being used. This should generally be within the
+# range set by MINCATWIDTH and MAXCATWIDTH.
+#
+#CATWIDTH	0
+#
+#---------------------------------------------------------
+# Flags.
+# NOCACHE keeps man from creating cat pages.
+#NOCACHE

--- a/recipe.yml
+++ b/recipe.yml
@@ -152,6 +152,11 @@ stages:
         - apt autoremove -y
         - apt clean
 
+    - name: add-manpath-config
+      type: shell
+      commands: 
+        - mv /etc/man-path.config /etc/manpath.config
+
     - name: enable-apt-hooks
       type: shell
       commands:


### PR DESCRIPTION
This PR adds the configuration file for resolving manpages. (I obtained this Debian `manpath.config` file from Xenia a while ago).

The file is initially included in the `includes.container` file as `man-path.config`. Adding it initially would fail the CI i.e. https://github.com/Vanilla-OS/vso-image/actions/runs/8894758773/job/24423680859 (since the CI environment doesn't have access to the system thus failing the `man-db` step invoked by APT).

As we discussed a while ago, I tested adding this file in the last step of the recipe and this works perfectly.

Now, all host man pages can be accessed inside the container (as well as man pages for commands installed in a container).

## Testing

I tested the change by building and pushing an image in my fork (https://github.com/kbdharun/vso-image/pkgs/container/vso) and then I built VSO modifying line 30 of `main.go` for my custom stack to work with this image locally.