### PR TITLE
fix: remove ping from the container

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -55,7 +55,6 @@ stages:
           - libkrb5-3
           - libcap2-bin
           - hostname
-          - iputils-ping
           - less
           - keyutils
           - libnss-mdns


### PR DESCRIPTION
Since ping is now provided by the host it needs to be removed from the container.