### PR TITLE
fix:[#44] add nvidia key to vso image

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -154,6 +154,11 @@ stages:
         # distrobox links
         - sh /usr/share/apx/distrobox/gen-distrobox-links
 
+    - name: repo-keys
+      type: shell
+      commands:
+        - curl -fSsL https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/3bf863cc.pub | gpg --dearmor -o /usr/share/keyrings/nvidia-drivers.gpg
+
     - name: cleanup
       type: shell
       commands:


### PR DESCRIPTION
add nvidia key to vso image so that apt works ootb on the nvidia-exp-image
```bash
/.system/usr/share/apx/distrobox/distrobox create --image localhost/vanillaos/vso-nvidia --name vso-nvidia-test-2 --nvidia --init
```
```
Creating 'vso-nvidia-test-2' using image localhost/vanillaos/vso-nvidia	 [ OK ]
Distrobox 'vso-nvidia-test-2' successfully created.
To enter, run:

apx vso-nvidia-test-2 enter
```
```bash
/.system/usr/share/apx/distrobox/distrobox enter vso-nvidia-test-2
jardon@vso-nvidia-test-2:~/Projects/vso-image$ sudo apt update
```
```
Hit:1 http://deb.debian.org/debian sid InRelease
Get:2 https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64  InRelease [1,581 B]
Get:3 https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64  Packages [608 kB]
Fetched 610 kB in 1s (708 kB/s)   
18 packages can be upgraded. Run 'apt list --upgradable' to see them.
```

closes #44 